### PR TITLE
Switch from floryn90/hugo to ghcr.io/gohugoio/hugo image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM floryn90/hugo:ext-alpine
+FROM ghcr.io/gohugoio/hugo
 
-RUN apk add git && \
-  git config --global --add safe.directory /src
+COPY . /project
+
+RUN npm i
+
+RUN hugo --minify


### PR DESCRIPTION
Switch from floryn90/hugo to ghcr.io/gohugoio/hugo image

The site build using docker-compose fails since floryn90/hugo v0.134.3:

```
Error: error building site: failed to acquire a build lock: open /src/.hugo_build.lock: permission denied
```

Cause: The Alpine image has switched from root user to hugo user:

https://github.com/floryn90/docker-hugo/commit/b26163074781850eba0151306837c55f8a2b5b1e

Fix: Switch to offical ghcr.io/gohugoio/hugo image that doesn't have the problem.