### PR TITLE
Update Docsy to main (pre-0.17.0) and provide Dart Sass

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -15,13 +15,13 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: stable
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -27,8 +27,6 @@ jobs:
           cache: npm
           cache-dependency-path: package.json
 
-      # No --omit=optional: sass-embedded resolves its platform binary
-      # through optional dependencies.
       - run: npm install
 
       - name: Install lychee

--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -27,7 +27,9 @@ jobs:
           cache: npm
           cache-dependency-path: package.json
 
-      - run: npm install --omit=optional
+      # No --omit=optional: sass-embedded resolves its platform binary
+      # through optional dependencies.
+      - run: npm install
 
       - name: Install lychee
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,23 @@
-FROM floryn90/hugo:ext-alpine
+FROM floryn90/hugo:0.164.0-ext-alpine
 
+# Provide the Dart Sass CLI, a Docsy build prerequisite since 0.17 (the
+# base image ships no Sass compiler).
+ARG DART_SASS_VERSION=1.102.0
+
+# The base image's NODE_PATH starts with a relative "." entry, which Hugo's
+# Node.js ESM resolver hook rejects (createRequire needs absolute paths).
+ENV NODE_PATH=/usr/local/lib/node_modules
+
+USER root
 RUN apk add git && \
-  git config --global --add safe.directory /src
+  git config --global --add safe.directory /src && \
+  arch="$(apk --print-arch)" && \
+  case "$arch" in \
+    x86_64) sassArch=x64 ;; \
+    aarch64) sassArch=arm64 ;; \
+    *) echo "unsupported architecture: $arch" && exit 1 ;; \
+  esac && \
+  wget -qO- "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-${sassArch}-musl.tar.gz" \
+    | tar -xz -C /usr/local && \
+  ln -s /usr/local/dart-sass/sass /usr/local/bin/sass
+USER hugo

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ FROM floryn90/hugo:0.164.0-ext-alpine
 ARG DART_SASS_VERSION=1.102.0
 
 # The base image's NODE_PATH starts with a relative "." entry, which Hugo's
-# Node.js ESM resolver hook rejects (createRequire needs absolute paths).
-ENV NODE_PATH=/usr/local/lib/node_modules
+# Node.js ESM resolver hook rejects, and its global modules can shadow the
+# project's own: the site supplies every Node dependency, so clear it.
+ENV NODE_PATH=
 
 USER root
 RUN apk add git && \

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Or the build may fail with:
 ```console
 $ hugo serve
 
-Error: error building site: ... TOCSS-DART: failed to transform "/scss/main.scss" (text/x-scss): You need to install Dart Sass
+Error: error building site: ... TOCSS-DART: failed to transform "/scss/main.scss" (text/x-scss). You need to install Dart Sass
 ```
 
 This error occurs when the `sass` CLI is not on your `PATH`. Run the site

--- a/README.md
+++ b/README.md
@@ -91,9 +91,8 @@ To invoke `hugo` directly instead, first put the `sass` CLI on your `PATH`; see
 You can run docsy-example inside a [Docker](https://docs.docker.com/) container,
 the container runs with a volume bound to the `docsy-example` folder. You need
 [Docker Desktop](https://www.docker.com/products/docker-desktop) on Windows and
-Mac, or [Docker Compose](https://docs.docker.com/compose/install/) on Linux.
-Note that the Docker setup is maintained on a best-effort basis: it is not
-officially supported, and not exercised by CI.
+Mac, or [Docker Compose](https://docs.docker.com/compose/install/) on Linux. The
+Docker setup is best-effort: not officially supported, and not exercised by CI.
 
 Because the container builds the site from your working copy, first install the
 site's npm dependencies as described in
@@ -159,9 +158,8 @@ or, when using npm, prepend `local` to the script you want to invoke, e.g.:
 npm run local serve
 ```
 
-Prefer the npm form: like every direct `hugo` invocation, the first command also
-requires the `sass` CLI on your `PATH` (see
-[Troubleshooting](#troubleshooting)).
+Prefer the npm form: the direct-`hugo` command needs the `sass` CLI on your
+`PATH` (see [Troubleshooting](#troubleshooting)).
 
 By using the `HUGO_MODULE_WORKSPACE` directive (either directly or via prefix
 `local` when using npm), the server now watches all files and directories inside

--- a/README.md
+++ b/README.md
@@ -89,10 +89,16 @@ To invoke `hugo` directly instead, first put the `sass` CLI on your `PATH`; see
 ## Running a container locally
 
 You can run docsy-example inside a [Docker](https://docs.docker.com/) container,
-the container runs with a volume bound to the `docsy-example` folder. This
-approach doesn't require you to install any dependencies other than
+the container runs with a volume bound to the `docsy-example` folder. You need
 [Docker Desktop](https://www.docker.com/products/docker-desktop) on Windows and
-Mac, and [Docker Compose](https://docs.docker.com/compose/install/) on Linux.
+Mac, or [Docker Compose](https://docs.docker.com/compose/install/) on Linux.
+Note that the Docker setup is maintained on a best-effort basis: it is not
+officially supported, and not exercised by CI.
+
+Because the container builds the site from your working copy, first install the
+site's npm dependencies as described in
+[Running the website locally](#running-the-website-locally) (`npm install`, run
+on your host). Then:
 
 1. Build the docker image
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,14 @@ runs a Hugo module command, `npm install` requires the `go` command; see
 Then run:
 
 ```bash
-hugo serve
+npm run serve
 ```
+
+The `serve` script runs `hugo serve` with the `sass` CLI from `node_modules` on
+the `PATH`: Docsy builds with
+[Dart Sass](https://www.docsy.dev/docs/get-started/docsy-as-module/installation-prerequisites/#install-dart-sass).
+To invoke `hugo` directly instead, first put the `sass` CLI on your `PATH`; see
+[Troubleshooting](#troubleshooting).
 
 ## Running a container locally
 
@@ -147,6 +153,10 @@ or, when using npm, prepend `local` to the script you want to invoke, e.g.:
 npm run local serve
 ```
 
+Prefer the npm form: like every direct `hugo` invocation, the first command also
+requires the `sass` CLI on your `PATH` (see
+[Troubleshooting](#troubleshooting)).
+
 By using the `HUGO_MODULE_WORKSPACE` directive (either directly or via prefix
 `local` when using npm), the server now watches all files and directories inside
 the sibling directory `../docsy` , too. Any changes inside the local `docsy`
@@ -214,6 +224,20 @@ hook), this can also surface during installation, not only when serving. See
 this
 [section](https://www.docsy.dev/docs/get-started/docsy-as-module/installation-prerequisites/#install-go-language)
 of the user guide for instructions on how to install `go`.
+
+Or the build may fail with:
+
+```console
+$ hugo serve
+
+Error: error building site: ... TOCSS-DART: failed to transform "/scss/main.scss" (text/x-scss): You need to install Dart Sass
+```
+
+This error occurs when the `sass` CLI is not on your `PATH`. Run the site
+through the npm scripts (for example, `npm run serve`), which put
+`node_modules/.bin` on the `PATH`, or install
+[Dart Sass](https://www.docsy.dev/docs/get-started/docsy-as-module/installation-prerequisites/#install-dart-sass)
+yourself.
 
 [alternate dashboard]: https://app.netlify.com/sites/goldydocs/deploys
 [deploys]: https://app.netlify.com/sites/docsy-example/deploys

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy/theme v0.16.0 // indirect
+require github.com/google/docsy/theme v0.16.1-0.20260825004502-dd6e5051726a // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/google/docsy/theme v0.16.0 h1:9uV9qEhk7UpJ8KYbSpTPQlq6htH+8hYskedgGZVnNsU=
 github.com/google/docsy/theme v0.16.0/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=
+github.com/google/docsy/theme v0.16.1-0.20260825004502-dd6e5051726a h1:6gKSIflQ3Q9398f3MmJWIPW5Vq6Mz7dYrWA6Fr6dGzI=
+github.com/google/docsy/theme v0.16.1-0.20260825004502-dd6e5051726a/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy-example-site",
-  "version": "0.16.1-dev+001-over-main-9e5d51b7",
+  "version": "0.16.1-dev+002-over-main-dd6e5051",
   "description": "Example site that uses Docsy theme for technical documentation.",
   "repository": "github:google/docsy-example",
   "homepage": "https://example.docsy.dev",
@@ -64,7 +64,8 @@
     "hugo-extended": "0.164.0",
     "link-cache": "^0.3.0",
     "postcss-cli": "^11.0.1",
-    "rtlcss": "^4.3.0"
+    "rtlcss": "^4.3.0",
+    "sass-embedded": "1.102.0"
   },
   "optionalDependencies": {
     "npm-check-updates": "^23.0.0",


### PR DESCRIPTION
- Contributes to google/docsy#2691.
- **Theme**: pins the module at docsy `main`, ahead of the 0.17.0 tag; the pin moves to the tag once released.
- **Dart Sass**: adds `sass-embedded` at the theme's tested pin, the new 0.17 build prerequisite; npm-run build paths pick it up from `node_modules/.bin`, and CI stops omitting optional deps, which sass-embedded needs for its platform binary.
- **Docker**: best-effort only, the Docker flow is not officially supported: provides the `sass` CLI in the image, pins the base image to the site's Hugo version, and works around a base-image `NODE_PATH` quirk that broke the RTL build.
- **Actions**: SHA-pins the links workflow's actions, required by the zizmor policy for any PR that touches a workflow.
- **Validation**: dev and production builds, site tests, and the offline link check pass; the built-CSS diff against 0.16 matches the release post: Dart Sass serialization changes plus the breadcrumb selector migration, nothing else.
- **Preview**: https://deploy-preview-486--goldydocs.netlify.app/
