### PR TITLE
Release 0.17.0

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -73,6 +73,7 @@ https://github.com/google/docsy-example,200,1782766676
 https://github.com/google/docsy-example/issues,200,1782766676
 https://github.com/google/docsy-example/pulls,200,1782766676
 https://github.com/google/docsy/releases/v0.16.0,200,1785357023
+https://github.com/google/docsy/releases/v0.17.0,200,1788122269
 https://github.com/google/docsy/tree/main/docsy.dev,200,1782766676
 https://github.com/kubeflow/website/blob/master/README.md,200,1782766676
 https://gohugo.io/,200,1782763743

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy/theme v0.16.1-0.20260828131726-54b561dccf11 // indirect
+require github.com/google/docsy/theme v0.16.1-0.20260829101401-36f73a06499c // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy/theme v0.16.1-0.20260829101401-36f73a06499c // indirect
+require github.com/google/docsy/theme v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/google/docsy/theme v0.16.1-0.20260829101401-36f73a06499c h1:xxm9WVJ9U+Mnc07HV341fI5/AwWe3h+O/8DjEPoDCcw=
-github.com/google/docsy/theme v0.16.1-0.20260829101401-36f73a06499c/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=
+github.com/google/docsy/theme v0.17.0 h1:eQaQcvg20bxI21nKylsERCK/xkCITj0Sqf3ae/NDRdo=
+github.com/google/docsy/theme v0.17.0/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/google/docsy/theme v0.16.1-0.20260828131726-54b561dccf11 h1:GUZTBpQrxI4DOAwm4k2d73lmny133kbZs3+G5I51w+U=
-github.com/google/docsy/theme v0.16.1-0.20260828131726-54b561dccf11/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=
+github.com/google/docsy/theme v0.16.1-0.20260829101401-36f73a06499c h1:xxm9WVJ9U+Mnc07HV341fI5/AwWe3h+O/8DjEPoDCcw=
+github.com/google/docsy/theme v0.16.1-0.20260829101401-36f73a06499c/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -128,7 +128,7 @@ params:
   # The version number for the version of the docs represented in this doc set.
   # Used in the "version-banner" partial to display a version number for the
   # current doc set.
-  version: 0.16.1-dev
+  version: 0.17.0
 
   # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
   github_repo: https://github.com/google/docsy-example

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -128,7 +128,7 @@ params:
   # The version number for the version of the docs represented in this doc set.
   # Used in the "version-banner" partial to display a version number for the
   # current doc set.
-  version: 0.17.0
+  version: 0.16.1-dev
 
   # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
   github_repo: https://github.com/google/docsy-example

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docsy-example-site",
-  "version": "0.16.1-dev+004-over-main-36f73a06",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docsy-example-site",
-      "version": "0.16.1-dev+004-over-main-36f73a06",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/hugoautogen"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docsy-example-site",
-  "version": "0.16.1-dev+003-over-main-54b561dc",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docsy-example-site",
-      "version": "0.16.1-dev+003-over-main-54b561dc",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/hugoautogen"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docsy-example-site",
-  "version": "0.17.0",
+  "version": "0.16.1-dev+004-over-main-36f73a06",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docsy-example-site",
-      "version": "0.17.0",
+      "version": "0.16.1-dev+004-over-main-36f73a06",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/hugoautogen"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy-example-site",
-  "version": "0.16.1-dev+004-over-main-36f73a06",
+  "version": "0.17.0",
   "description": "Example site that uses Docsy theme for technical documentation.",
   "repository": "github:google/docsy-example",
   "homepage": "https://example.docsy.dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy-example-site",
-  "version": "0.17.0",
+  "version": "0.16.1-dev+004-over-main-36f73a06",
   "description": "Example site that uses Docsy theme for technical documentation.",
   "repository": "github:google/docsy-example",
   "homepage": "https://example.docsy.dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy-example-site",
-  "version": "0.16.1-dev+003-over-main-54b561dc",
+  "version": "0.17.0",
   "description": "Example site that uses Docsy theme for technical documentation.",
   "repository": "github:google/docsy-example",
   "homepage": "https://example.docsy.dev",


### PR DESCRIPTION
- **Theme pin**: moves to the `v0.17.0` tag via `update:docsy:mod`; carries the theme changes since the previous `54b561dc` pin (theme-toggler assistive-text localization, google/docsy#2758) -- verified rendered in the built locales.
- **Version identity**: manifest and site-info badge set to 0.17.0, per the release-commit convention (#483); `.lycheecache` picks up the now-live release-page URL.
- **Validation**: full `npm run test` green (build, online link check incl. fragments, 8/8 site tests); post's sanity checks pass (woff2-only webfonts, localized mode-menu labels, badge link).
