### PR TITLE
Set site version to 0.17.1-dev

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -128,7 +128,7 @@ params:
   # The version number for the version of the docs represented in this doc set.
   # Used in the "version-banner" partial to display a version number for the
   # current doc set.
-  version: 0.17.0
+  version: 0.17.1-dev
 
   # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
   github_repo: https://github.com/google/docsy-example

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docsy-example-site",
-  "version": "0.17.0",
+  "version": "0.17.1-dev+002-over-main-d121f75e",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docsy-example-site",
-      "version": "0.17.0",
+      "version": "0.17.1-dev+002-over-main-d121f75e",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/hugoautogen"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy-example-site",
-  "version": "0.17.0",
+  "version": "0.17.1-dev+002-over-main-d121f75e",
   "description": "Example site that uses Docsy theme for technical documentation.",
   "repository": "github:google/docsy-example",
   "homepage": "https://example.docsy.dev",


### PR DESCRIPTION
- Stamps the post-0.17.0 dev version via `set:version:example:git-info`, per the [maintainer notes followup step](https://www.docsy.dev/project/about/maintainer-notes/#post-docsy-release-followup); sibling to [google/docsy#2773](https://github.com/google/docsy/pull/2773), precedent: #484
- Syncs the committed lockfile's root version fields (first stamp since the lock landed); leaves the `hugoautogen` workspace at its own version — the stamp script's lock-sync overreach there is a docsy-repo followup
