### PR TITLE
Renovate: group patch and minor updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,11 +41,13 @@ Renovate opens version-update PRs, created on Sundays, configured in
   committed lockfile; transitive security fixes arrive alert-driven instead.
 - `gomod` off: the Docsy theme pin is updated manually; see
   [Upgrade Docsy](#upgrade-docsy). All other detected managers are active.
-- Package rules: `hugo-extended` is version-pinned and coupled to its
-  `allowScripts` approval (see [Update Hugo](#update-hugo)); bootstrap and Font
-  Awesome updates route through the theme (`packages/hugoautogen` is regenerated
-  from the theme, reverting any direct bump). A Dependabot security PR may still
-  bump these directly: close it and route the fix through a theme update.
+- Package rules: patch and minor updates are each grouped into a single PR per
+  wave (majors stay individual); `hugo-extended` is version-pinned and coupled
+  to its `allowScripts` approval (see [Update Hugo](#update-hugo)); bootstrap
+  and Font Awesome updates route through the theme (`packages/hugoautogen` is
+  regenerated from the theme, reverting any direct bump). A Dependabot security
+  PR may still bump these directly: close it and route the fix through a theme
+  update.
 
 Renovate's vulnerability-alert PRs stay on (immediate, cooldown-exempt), beside
 GitHub's Dependabot security updates; a rare duplicate PR is accepted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,13 +41,16 @@ Renovate opens version-update PRs, created on Sundays, configured in
   committed lockfile; transitive security fixes arrive alert-driven instead.
 - `gomod` off: the Docsy theme pin is updated manually; see
   [Upgrade Docsy](#upgrade-docsy). All other detected managers are active.
-- Package rules: patch and minor updates are each grouped into a single PR per
-  wave (majors stay individual); `hugo-extended` is version-pinned and coupled
-  to its `allowScripts` approval (see [Update Hugo](#update-hugo)); bootstrap
-  and Font Awesome updates route through the theme (`packages/hugoautogen` is
-  regenerated from the theme, reverting any direct bump). A Dependabot security
-  PR may still bump these directly: close it and route the fix through a theme
-  update.
+- Package rules:
+  - Patch and minor updates are each grouped into a single PR per wave, to cut
+    review overhead. Majors stay individual, except families that Renovate's
+    presets keep in lockstep (for example, the GitHub artifact actions).
+  - `hugo-extended` is version-pinned and coupled to its `allowScripts` approval
+    (see [Update Hugo](#update-hugo)).
+  - Bootstrap and Font Awesome updates route through the theme
+    (`packages/hugoautogen` is regenerated from the theme, reverting any direct
+    bump). A Dependabot security PR may still bump these directly: close it and
+    route the fix through a theme update.
 
 Renovate's vulnerability-alert PRs stay on (immediate, cooldown-exempt), beside
 GitHub's Dependabot security updates; a rare duplicate PR is accepted.

--- a/renovate.json5
+++ b/renovate.json5
@@ -12,6 +12,14 @@
   minimumReleaseAge: '7 days',
   packageRules: [
     {
+      groupName: 'all patch versions',
+      matchUpdateTypes: ['patch'],
+    },
+    {
+      groupName: 'all minor versions',
+      matchUpdateTypes: ['minor'],
+    },
+    {
       matchPackageNames: ['hugo-extended'],
       enabled: false, // Manually updated to match Docsy requirements
     },


### PR DESCRIPTION
- **Groups** patch updates and minor updates into one Renovate PR each per weekly wave, mirroring the config merged in google/docsy#2776; documents the grouping in CONTRIBUTING.md's package-rules rationale
- **Majors** stay individual, except families Renovate's presets keep in lockstep (e.g. the GitHub artifact actions)
