### PR TITLE
Update Docsy to main (jQuery drop)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/docsy-example
 
 go 1.12
 
-require github.com/google/docsy/theme v0.17.0 // indirect
+require github.com/google/docsy/theme v0.17.1-0.20260831231032-2c44726e7773 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/google/docsy/theme v0.17.0 h1:eQaQcvg20bxI21nKylsERCK/xkCITj0Sqf3ae/NDRdo=
-github.com/google/docsy/theme v0.17.0/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=
+github.com/google/docsy/theme v0.17.1-0.20260831231032-2c44726e7773 h1:hEh0qXu/KXXh7hobVkqh4jTZUnwh/PbI7FHhqPfS+9U=
+github.com/google/docsy/theme v0.17.1-0.20260831231032-2c44726e7773/go.mod h1:NX/JqXCbZBn9Q2Hj7ez9Xeh9z4XcLiwmDYZXhB4RhRM=

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docsy-example-site",
-  "version": "0.17.1-dev+004-over-main-2c44726e",
+  "version": "0.17.1-dev+006-over-main-2c44726e",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docsy-example-site",
-      "version": "0.17.1-dev+004-over-main-2c44726e",
+      "version": "0.17.1-dev+006-over-main-2c44726e",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/hugoautogen"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docsy-example-site",
-  "version": "0.17.1-dev+002-over-main-d121f75e",
+  "version": "0.17.1-dev+004-over-main-2c44726e",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docsy-example-site",
-      "version": "0.17.1-dev+002-over-main-d121f75e",
+      "version": "0.17.1-dev+004-over-main-2c44726e",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/hugoautogen"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy-example-site",
-  "version": "0.17.1-dev+002-over-main-d121f75e",
+  "version": "0.17.1-dev+004-over-main-2c44726e",
   "description": "Example site that uses Docsy theme for technical documentation.",
   "repository": "github:google/docsy-example",
   "homepage": "https://example.docsy.dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy-example-site",
-  "version": "0.17.1-dev+004-over-main-2c44726e",
+  "version": "0.17.1-dev+006-over-main-2c44726e",
   "description": "Example site that uses Docsy theme for technical documentation.",
   "repository": "github:google/docsy-example",
   "homepage": "https://example.docsy.dev",


### PR DESCRIPTION
- Updates the theme pin to Docsy `main` at 2c44726e, the first jQuery-free Docsy (google/docsy#2777): the example site now ships and loads no jQuery
- Validated locally: full test suite green (build, links, site tests), rendered pages carry no jquery script or global
